### PR TITLE
Feature/optimize package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+/images
+/src
+jest.config.js
+tsconfig.json

--- a/package.json
+++ b/package.json
@@ -60,14 +60,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@size-limit/preset-small-lib": "^7.0.8",
-    "@types/react": "^17.0.38",
     "date-fns": "^2.28.0",
-    "husky": "^7.0.4",
-    "size-limit": "^7.0.8",
-    "tsdx": "^0.14.1",
-    "tslib": "^2.3.1",
-    "typescript": "^4.6.3",
     "use-debounce": "^7.0.1"
   },
   "keywords": [
@@ -84,9 +77,16 @@
   ],
   "devDependencies": {
     "@faker-js/faker": "^6.1.2",
+    "@size-limit/preset-small-lib": "^7.0.8",
     "@types/jest": "^27.4.0",
+    "@types/react": "^17.0.38",
     "bundlewatch": "^0.3.3",
+    "husky": "^7.0.4",
     "jest": "^27.5.1",
-    "ts-jest": "^27.1.3"
+    "size-limit": "^7.0.8",
+    "ts-jest": "^27.1.3",
+    "tsdx": "^0.14.1",
+    "tslib": "^2.3.1",
+    "typescript": "^4.6.3"
   }
 }


### PR DESCRIPTION
Hi @karolkozer,

Great work on this package, it is very promising and the UI looks clean.

I've submitted this PR to optimize the package download size when installing it via NPM or Yarn. 

First, I've moved all dependencies used while developing to the devDependencies. This prevents installing these dependencies in projects that use the `planby` package.

Secondly, I've also added a .npmignore file which prevents specific folders and files from being packaged when publishing a version to NPM. The `src` and `images` folders are not needed, saving some disk size.

Using the sandbox demo as an example, this change saves around 240MB on the node_modules folder.

Before the change:

```
~/Downloads/planby-epg-demo> du -sh *
586M	node_modules
4.0K	package.json
4.0K	public
1.6M	src
```

And after:

```
~/Downloads/planby-epg-demo> du -sh *
342M	node_modules
4.0K	package.json
4.0K	public
1.6M	src
```

Let me know what you think! ✌️ 