### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ import { useEpg, Epg, Layout } from 'planby';
 const channels = React.useMemo(
   () => [
     {
-      logo: 'https://via.placeholder.com',
+      logo: 'https://placehold.co/80x80',
       uuid: '10339a4b-7c48-40ab-abad-f3bcaf95d9fa',
       ...
     },
@@ -109,7 +109,7 @@ const epg = React.useMemo(
       description:
         'Ut anim nisi consequat minim deserunt...',
       id: 'b67ccaa3-3dd2-4121-8256-33dbddc7f0e6',
-      image: 'https://via.placeholder.com',
+      image: 'https://placehold.co/300x150',
       since: "2022-02-02T23:50:00",
       till: "2022-02-02T00:55:00",
       title: 'Title',


### PR DESCRIPTION
`README.md` references `via.placeholder.com/...` URLs. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Browsers render a broken-image icon in place of the intended placeholder.

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo 'connection refused / DNS gone'
```

#### What this PR changes

Fixes the EPG `logo` and `image` example URLs in the planby README so the canonical TV-guide example works when developers copy-paste the snippet into their project.

#### Replacement details

Added explicit dimensions (80×80 for channel logo, 300×150 for show image) because `via.placeholder.com` without a size parameter defaulted to a host-selected default — `placehold.co` returns 400 without explicit dims, so the size is set to a sensible default for each context.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** introduced as a dependency by this PR — the diff uses the dependency-free canonical replacement domain. If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering the broader broken-placeholder landscape: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
